### PR TITLE
Overload publishMessage

### DIFF
--- a/MqttLibrary/build.gradle
+++ b/MqttLibrary/build.gradle
@@ -18,7 +18,7 @@ plugins {
 }
 
 group 'com.craxiom'
-version '0.5.0'
+version '0.6.0'
 
 android {
     compileSdkVersion 33
@@ -27,7 +27,7 @@ android {
     defaultConfig {
         minSdkVersion 24
         targetSdkVersion 33
-        versionCode 11
+        versionCode 12
         versionName version
 
         setProperty("archivesBaseName", "$applicationName-$versionName")

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ It is important to note that the pieces provided in the library cannot stand on 
 
 
 ## Change log
+##### 0.6.0 - 2023-07-17
+* Overload the publishMessage method to enable sending plain JSON strings.
+
 ##### [0.5.0](https://github.com/christianrowlands/android-mqtt-connection-lib/releases/tag/v0.5.0) - 2022-10-25
 * Change the onMdmOverride method to protected so it can be overridden
 


### PR DESCRIPTION
We have an app concerned with sending only JSON strings across to an MQTT broker. Since  `DefaultMqttConnection#publishMessage`  already transforms proto messages into JSON, overloading the method seemed like a simple way to solve this issue.